### PR TITLE
Raison de suppression : Pas de possibilité de stocker des sauts de li…

### DIFF
--- a/src/Components/Containers/DataGrid/UpDefaultCellFormatter.tsx
+++ b/src/Components/Containers/DataGrid/UpDefaultCellFormatter.tsx
@@ -164,7 +164,7 @@ export class UpCellFormatter extends React.Component<UpCellFormatterProps, {}>{
             case 'time':
                 return <span>{moment(valueExtracted).format("HH:mm")}</span>
             case "multilineText":
-                return <span style={{ "whiteSpace": "pre" }}>{valueExtracted}</span>
+                return <span>{valueExtracted}</span>
             case "boolean":
                 switch (valueExtracted) {
                     case true:


### PR DESCRIPTION
…gne dans BDD. Propriété qui ne permet pas une rupture de longue phrase.